### PR TITLE
set physical memory protection and remove redundant macros

### DIFF
--- a/inc/riscv.h
+++ b/inc/riscv.h
@@ -17,14 +17,6 @@ static inline uint64_t r_mhartid() {
     return x;
 }
 
-// Machine Status Register, mstatus
-
-#define MSTATUS_MPP_MASK (3L << 11)  // previous mode.
-#define MSTATUS_MPP_M (3L << 11)
-#define MSTATUS_MPP_S (1L << 11)
-#define MSTATUS_MPP_U (0L << 11)
-#define MSTATUS_MIE (1L << 3)  // machine-mode interrupt enable.
-
 static inline uint64_t r_mstatus() {
     uint64_t x;
     asm volatile("csrr %0, mstatus" : "=r"(x));
@@ -69,6 +61,14 @@ static inline uint64_t r_sip() {
 
 static inline void w_sip(uint64_t x) {
     asm volatile("csrw sip, %0" : : "r"(x));
+}
+
+static inline void w_pmpcfg0(uint64_t x) {
+    asm volatile("csrw pmpcfg0, %0" : : "r"(x));
+}
+
+static inline void w_pmpaddr0(uint64_t x) {
+    asm volatile("csrw pmpaddr0, %0" : : "r"(x));
 }
 
 // Supervisor Interrupt Enable

--- a/src/start.c
+++ b/src/start.c
@@ -20,6 +20,10 @@ void start() {
     // disable paging for now.
     w_satp(0);
 
+    // physical memory protection
+    w_pmpcfg0(0xf);
+    w_pmpaddr0(0xffffffffffffffff);
+
     // delegate all interrupts and exceptions to supervisor mode.
     w_medeleg(0xffff);
     w_mideleg(0xffff);


### PR DESCRIPTION
Configuring PMP registers seems to be necessary for the example to work now.